### PR TITLE
feat: Added feature flag on caching for mock responses

### DIFF
--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -67,6 +67,7 @@ microservice-chart:
     DEFAULT_LOGGING_LEVEL: 'INFO'
     REDIS_HOST: "pagopa-d-redis.redis.cache.windows.net"
     REDIS_PORT: "6380"
+    MOCKER_CACHE_ENABLED: 'false'
   envSecret:
     MONGODB_CONNECTION_URI: 'db-mocker-uri'
     REDIS_PASSWORD: 'redis-password'

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -67,6 +67,7 @@ microservice-chart:
     DEFAULT_LOGGING_LEVEL: 'INFO'
     REDIS_HOST: "pagopa-d-redis.redis.cache.windows.net"
     REDIS_PORT: "6380"
+    MOCKER_CACHE_ENABLED: 'false'
   envSecret:
     MONGODB_CONNECTION_URI: 'db-mocker-uri'
     REDIS_PASSWORD: 'redis-password'

--- a/src/main/java/it/gov/pagopa/mocker/entity/MockResponseEntity.java
+++ b/src/main/java/it/gov/pagopa/mocker/entity/MockResponseEntity.java
@@ -19,6 +19,8 @@ public class MockResponseEntity implements Serializable {
 
     private int status;
 
+    private Boolean isCacheable;
+
     private List<String> parameters;
 
     private List<ResponseHeaderEntity> headers;

--- a/src/main/java/it/gov/pagopa/mocker/service/validator/ResourceExtractor.java
+++ b/src/main/java/it/gov/pagopa/mocker/service/validator/ResourceExtractor.java
@@ -208,7 +208,7 @@ public class ResourceExtractor {
         }
         return ExtractedResponse.builder()
                 .body(decodedBody)
-                .isCacheable(true)
+                .isCacheable(mockResponse.getIsCacheable() == null || mockResponse.getIsCacheable())
                 .status(mockResponse.getStatus())
                 .headers(headers)
                 .build();

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -22,3 +22,5 @@ logging.level.org.hibernate=ERROR
 spring.redis.host=${REDIS_HOST}
 spring.redis.port=${REDIS_PORT}
 spring.redis.pwd=${REDIS_PASSWORD}
+
+mocker.cache.enabled=false

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -23,4 +23,4 @@ spring.redis.host=${REDIS_HOST}
 spring.redis.port=${REDIS_PORT}
 spring.redis.pwd=${REDIS_PASSWORD}
 
-mocker.cache.enabled=false
+mocker.cache.enabled=${MOCKER_CACHE_ENABLED:false}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,3 +17,5 @@ logging.level.org.hibernate=ERROR
 spring.redis.host=${REDIS_HOST}
 spring.redis.port=${REDIS_PORT}
 spring.redis.pwd=${REDIS_PASSWORD}
+
+mocker.cache.enabled=${MOCKER_CACHE_ENABLED}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -20,3 +20,5 @@ logging.level.org.hibernate=ERROR
 spring.redis.host=localhost
 spring.redis.port=1234
 spring.redis.pwd=password
+
+mocker.cache.enabled=false


### PR DESCRIPTION
This PR contains a new feature made in order to enable or disable the response caching. This flag permits to disable the response caching and its retrieve if needed.  
Also, the handling of cachability of single responses is upgraded in order to provide an optional caching of single response using a specific flag in mock response persisted object.

#### List of Changes
 - Added feature flag for explicitly enabling response caching process 
 - Added handling of `isCacheable` field for persisted mock response, in order to provide optional caching for responses

#### Motivation and Context
This feature is needed because the response caching process is a beta feature that must be tuned with several tests and it is not completely ready yet.

#### How Has This Been Tested?
 - Tested in local environment

#### Screenshots (if appropriate):

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.