### PR TITLE
feat: moved from SOAPAction to multiple special headers handling

### DIFF
--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -69,6 +69,7 @@ microservice-chart:
     REDIS_HOST: "pagopa-d-redis.redis.cache.windows.net"
     REDIS_PORT: "6380"
     MOCKER_CACHE_ENABLED: 'false'
+    MOCKER_REQUEST_SPECIALHEADERS: 'soapaction,x-host-url,x-host-port,x-host-path'
   secretProvider:
     create: true
     envSecrets:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -69,6 +69,7 @@ microservice-chart:
     REDIS_HOST: "pagopa-d-redis.redis.cache.windows.net"
     REDIS_PORT: "6380"
     MOCKER_CACHE_ENABLED: 'false'
+    MOCKER_REQUEST_SPECIALHEADERS: 'soapaction,x-host-url,x-host-port,x-host-path'
   secretProvider:
     create: true
     envSecrets:

--- a/src/main/java/it/gov/pagopa/mocker/controller/ProxyServlet.java
+++ b/src/main/java/it/gov/pagopa/mocker/controller/ProxyServlet.java
@@ -13,11 +13,13 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.context.support.SpringBeanAutowiringSupport;
 
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -28,6 +30,9 @@ public class ProxyServlet extends HttpServlet {
 
     @Autowired
     private HealthCheckService healthCheckService;
+
+    @Value("${mocker.request.accepted-special-headers}")
+    private Set<String> acceptedSpecialHeaders;
 
     @Override
     public void init(ServletConfig config) throws ServletException {
@@ -80,7 +85,7 @@ public class ProxyServlet extends HttpServlet {
             log.info(String.format("Trying to mocking the response for the called resource: [%s]", request.getRequestURI()));
             String body = request.getReader().lines().collect(Collectors.joining(System.lineSeparator()));
             /* Extracting mock response */
-            ExtractedResponse extractedResponse = proxyService.extract(ExtractedRequest.extract(request, body));
+            ExtractedResponse extractedResponse = proxyService.extract(ExtractedRequest.extract(request, body, acceptedSpecialHeaders));
             /* Update HttpServletResponse response */
             response.setStatus(extractedResponse.getStatus());
             response.setCharacterEncoding("UTF-8");

--- a/src/main/java/it/gov/pagopa/mocker/entity/MockResourceEntity.java
+++ b/src/main/java/it/gov/pagopa/mocker/entity/MockResourceEntity.java
@@ -24,9 +24,9 @@ public class MockResourceEntity implements Serializable {
 
     private String resourceUrl;
 
-    private String action;
-
     private HttpMethod httpMethod;
+
+    private List<SpecialRequestHeaderEntity> specialHeaders;
 
     private Boolean isActive;
 

--- a/src/main/java/it/gov/pagopa/mocker/entity/SpecialRequestHeaderEntity.java
+++ b/src/main/java/it/gov/pagopa/mocker/entity/SpecialRequestHeaderEntity.java
@@ -1,0 +1,19 @@
+package it.gov.pagopa.mocker.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class SpecialRequestHeaderEntity implements Serializable {
+
+    private String name;
+
+    private String value;
+}

--- a/src/main/java/it/gov/pagopa/mocker/exception/MockerNotRegisteredException.java
+++ b/src/main/java/it/gov/pagopa/mocker/exception/MockerNotRegisteredException.java
@@ -1,8 +1,10 @@
 package it.gov.pagopa.mocker.exception;
 
+import it.gov.pagopa.mocker.model.ExtractedRequest;
+
 public class MockerNotRegisteredException extends MockerException {
 
-    public MockerNotRegisteredException(String url) {
-        super(String.format("No valid mock resource is registered at URL [%s].", url));
+    public MockerNotRegisteredException(ExtractedRequest extractedRequest) {
+        super(String.format("No valid mock resource is registered as: HTTP Method [%s] - URL [%s] - Special Headers [%s].", extractedRequest.getMethod(), extractedRequest.getUrl(), extractedRequest.getSpecialHeaders()));
     }
 }

--- a/src/main/java/it/gov/pagopa/mocker/service/MockerService.java
+++ b/src/main/java/it/gov/pagopa/mocker/service/MockerService.java
@@ -44,7 +44,7 @@ public class MockerService {
     }
 
     private MockResourceEntity getMockResourceFromDB(ExtractedRequest requestData) throws MockerNotRegisteredException, MockerNotActiveException {
-        MockResourceEntity mockResource = dao.findById(requestData.getId()).orElseThrow(() -> new MockerNotRegisteredException(requestData.getUrl()));
+        MockResourceEntity mockResource = dao.findById(requestData.getId()).orElseThrow(() -> new MockerNotRegisteredException(requestData));
         if (Boolean.FALSE.equals(mockResource.getIsActive())) {
             throw new MockerNotActiveException(requestData.getUrl());
         }

--- a/src/main/java/it/gov/pagopa/mocker/service/ProxyService.java
+++ b/src/main/java/it/gov/pagopa/mocker/service/ProxyService.java
@@ -59,15 +59,15 @@ public class ProxyService {
         if (!Utility.isNullOrEmpty(excludeHeadersfromCache)) {
             exclusionInRuntime.addAll(Stream.of(excludeHeadersfromCache.split(","))
                     .map(header -> header.toLowerCase().trim())
-                    .collect(Collectors.toList()));
+                    .toList());
         }
         List<String> formattedHeaders = headers.keySet()
                 .stream()
                 .sorted()
                 .filter(headerKey -> (!Constants.NOT_CACHEABLE_HEADERS.contains(headerKey.toLowerCase()) && !exclusionInRuntime.contains(headerKey.toLowerCase())))
                 .map(headerKey -> String.format("\"%s\":\"%s\"", headerKey, headers.get(headerKey)))
-                .collect(Collectors.toList());
-        return "headers:" + formattedHeaders.toString() + ";";
+                .toList();
+        return "headers:" + formattedHeaders + ";";
     }
 
     private String extractQueryParameterSubstring(Map<String, String> queryParameters) {

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -24,3 +24,4 @@ spring.redis.port=${REDIS_PORT}
 spring.redis.pwd=${REDIS_PASSWORD}
 
 mocker.cache.enabled=${MOCKER_CACHE_ENABLED:false}
+mocker.request.accepted-special-headers=${MOCKER_REQUEST_SPECIALHEADERS}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,3 +19,4 @@ spring.redis.port=${REDIS_PORT}
 spring.redis.pwd=${REDIS_PASSWORD}
 
 mocker.cache.enabled=${MOCKER_CACHE_ENABLED}
+mocker.request.accepted-special-headers=${MOCKER_REQUEST_SPECIALHEADERS}


### PR DESCRIPTION
This PR contains several changes made on header evaluation in request that arrives to Mocker. The new handling permits to handle multiple headers, removing the fixed single-header analysis of SOAPAction.  
The multiple headers must be added in a dedicated environment variable in order to accept new keys.

#### List of Changes
 - Added logic for handle semi-dynamic special headers
 - Refactored DocumentDB entity, replacing `action` field with `specialHeaders`
 - Refactored Hash generation, changing the order of fields implied in hashing

#### Motivation and Context
This change is required in order to handle multiple variable headers instead of single SOAPAction header.

#### How Has This Been Tested?
 - Tested in local environment
 - Tested in DEV environment

#### Screenshots (if appropriate):

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.