### PR TITLE
fix: added required special headers in response

### DIFF
--- a/src/main/java/it/gov/pagopa/mocker/controller/ProxyServlet.java
+++ b/src/main/java/it/gov/pagopa/mocker/controller/ProxyServlet.java
@@ -18,6 +18,7 @@ import org.springframework.web.context.support.SpringBeanAutowiringSupport;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -32,7 +33,10 @@ public class ProxyServlet extends HttpServlet {
     private HealthCheckService healthCheckService;
 
     @Value("${mocker.request.accepted-special-headers}")
-    private Set<String> acceptedSpecialHeaders;
+    private HashSet<String> acceptedSpecialHeaders;
+
+    @Value("${mocker.request.accepted-clients}")
+    private HashSet<String> acceptedClients;
 
     @Override
     public void init(ServletConfig config) throws ServletException {
@@ -41,36 +45,28 @@ public class ProxyServlet extends HttpServlet {
     }
 
     @Override
-    protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
-        String url = req.getRequestURI().replace(Constants.MOCKER_PATH_ROOT, Constants.EMPTY_STRING);
-        if ("/info".equals(url)) {
+    protected void service(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        String method = req.getMethod();
+        boolean analyzeRequest = true;
+        if (method.equals("GET") && req.getRequestURI().startsWith(Constants.MOCKER_PATH_ROOT + "/info")) {
+            analyzeRequest = false;
             getAppInfo(resp);
-        } else {
+            addCorsAllowHeaders(resp);
+        } else if (method.equals("OPTIONS")) {
+            analyzeRequest = false;
+            super.doOptions(req, resp);
+            addCorsAllowHeaders(resp);
+        }
+
+        if (analyzeRequest) {
             analyzeRequest(req, resp);
         }
-    }
-
-    @Override
-    protected void doPost(HttpServletRequest req, HttpServletResponse resp) {
-        analyzeRequest(req, resp);
-    }
-
-    @Override
-    protected void doPut(HttpServletRequest req, HttpServletResponse resp) {
-        analyzeRequest(req, resp);
-    }
-
-    @Override
-    protected void doDelete(HttpServletRequest req, HttpServletResponse resp) {
-        analyzeRequest(req, resp);
     }
 
     private void getAppInfo(HttpServletResponse response)  {
         try {
             response.setStatus(200);
             response.setContentType(Constants.APPLICATION_JSON);
-            response.setHeader("Access-Control-Allow-Origin", "*");
-            response.setHeader("Access-Control-Allow-Credentials", "*");
             AppInfo info = healthCheckService.getAppInfo();
             response.getWriter().append(info.toString());
         } catch (IOException e) {
@@ -85,13 +81,18 @@ public class ProxyServlet extends HttpServlet {
             log.info(String.format("Trying to mocking the response for the called resource: [%s]", request.getRequestURI()));
             String body = request.getReader().lines().collect(Collectors.joining(System.lineSeparator()));
             /* Extracting mock response */
-            ExtractedResponse extractedResponse = proxyService.extract(ExtractedRequest.extract(request, body, acceptedSpecialHeaders));
+            ExtractedRequest extractedRequest = ExtractedRequest.extract(request, body, acceptedSpecialHeaders);
+            ExtractedResponse extractedResponse = proxyService.extract(extractedRequest);
             /* Update HttpServletResponse response */
             response.setStatus(extractedResponse.getStatus());
             response.setCharacterEncoding("UTF-8");
-            response.setContentType(extractedResponse.getHeaders().get("content-type"));
             for (Map.Entry<String, String> headerPair : extractedResponse.getHeaders().entrySet()) {
                 response.setHeader(headerPair.getKey(), headerPair.getValue());
+            }
+            response.setContentType(extractedResponse.getHeaders().get("content-type"));
+            response.setHeader("X-Powered-By", "Mocker");
+            if (acceptedClients.contains(extractedRequest.getHeaders().get("x-source-client"))) {
+                addCorsAllowHeaders(response);
             }
             PrintWriter writer = response.getWriter();
             writer.print(extractedResponse.getBody());
@@ -100,5 +101,12 @@ public class ProxyServlet extends HttpServlet {
         } catch (IOException e) {
             log.error("Something failed during writing response for proxy servlet.", e);
         }
+    }
+
+    private void addCorsAllowHeaders(HttpServletResponse response) {
+        response.setHeader("Access-Control-Allow-Origin", "*");
+        response.setHeader("Access-Control-Allow-Credentials", "*");
+        response.setHeader("Access-Control-Allow-Headers", "*");
+        response.setHeader("Access-Control-Expose-Headers", "*");
     }
 }

--- a/src/main/java/it/gov/pagopa/mocker/model/enumeration/HttpMethod.java
+++ b/src/main/java/it/gov/pagopa/mocker/model/enumeration/HttpMethod.java
@@ -5,6 +5,5 @@ public enum HttpMethod {
     POST,
     PUT,
     DELETE,
-    PATCH,
-    OPTIONS
+    PATCH
 }

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -25,3 +25,4 @@ spring.redis.pwd=${REDIS_PASSWORD}
 
 mocker.cache.enabled=${MOCKER_CACHE_ENABLED:false}
 mocker.request.accepted-special-headers=${MOCKER_REQUEST_SPECIALHEADERS}
+mocker.request.accepted-clients=${MOCKER_ACCEPTED_CLIENTS:pagopa-shared-toolbox}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,3 +20,4 @@ spring.redis.pwd=${REDIS_PASSWORD}
 
 mocker.cache.enabled=${MOCKER_CACHE_ENABLED}
 mocker.request.accepted-special-headers=${MOCKER_REQUEST_SPECIALHEADERS}
+mocker.request.accepted-clients=${MOCKER_ACCEPTED_CLIENTS:pagopa-shared-toolbox}


### PR DESCRIPTION
This PR contains the inclusion of special headers, needed for CORS handling. These headers are required after an integration test with "pagoPA Shared Toolbox" portal, due to the fact that preflight request does not permits to Mocker response to be correctly handled.  
Also, a new header named `X-Powered-By` is added in order to add the possibility to better track mock responses. 

#### List of Changes
 - Added `Access-Control-*` headers, for CORS handling
 - Added `X-Powered-By` header, for informative tracking
 - Refactored proxy servlet in order to centralize all HTTP method handling

#### Motivation and Context
This change is required for a correct integration between Mocker and other clients, such as pagoPA Shared Toolbox

#### How Has This Been Tested?
 - Tested in local environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.