### PR TITLE
fix: set default Content-Type if not set in mock response

### DIFF
--- a/src/main/java/it/gov/pagopa/mocker/controller/ProxyServlet.java
+++ b/src/main/java/it/gov/pagopa/mocker/controller/ProxyServlet.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -89,7 +88,7 @@ public class ProxyServlet extends HttpServlet {
             for (Map.Entry<String, String> headerPair : extractedResponse.getHeaders().entrySet()) {
                 response.setHeader(headerPair.getKey(), headerPair.getValue());
             }
-            response.setContentType(extractedResponse.getHeaders().get("content-type"));
+            addContentType(response, extractedRequest, extractedResponse);
             response.setHeader("X-Powered-By", "Mocker");
             if (acceptedClients.contains(extractedRequest.getHeaders().get("x-source-client"))) {
                 addCorsAllowHeaders(response);
@@ -108,5 +107,13 @@ public class ProxyServlet extends HttpServlet {
         response.setHeader("Access-Control-Allow-Credentials", "*");
         response.setHeader("Access-Control-Allow-Headers", "*");
         response.setHeader("Access-Control-Expose-Headers", "*");
+    }
+
+    private void addContentType(HttpServletResponse response, ExtractedRequest extractedRequest, ExtractedResponse extractedResponse) {
+        String contentType = extractedResponse.getHeaders().get("content-type");
+        if (contentType == null) {
+            contentType = extractedRequest.getContentType();
+        }
+        response.setContentType(contentType);
     }
 }


### PR DESCRIPTION
This PR contains a fix made on response generation in order to always returns the value of the request content-type if mock response does not define this header.

#### List of Changes
 - Defined `Content-Type` header value setting with one defined in request

#### Motivation and Context
This change is required in order to add more resilience to Mocker system

#### How Has This Been Tested?
 - Tested in local environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.