### PR TITLE
fix: Resolved wrong MockerNotCompliantRequestException if request body is not passed

### DIFF
--- a/src/main/java/it/gov/pagopa/mocker/service/ProxyService.java
+++ b/src/main/java/it/gov/pagopa/mocker/service/ProxyService.java
@@ -61,6 +61,7 @@ public class ProxyService {
                     .map(header -> header.toLowerCase().trim())
                     .toList());
         }
+        headers.putIfAbsent("content-type", "text/plain");
         List<String> formattedHeaders = headers.keySet()
                 .stream()
                 .sorted()

--- a/src/main/java/it/gov/pagopa/mocker/service/validator/ResourceExtractor.java
+++ b/src/main/java/it/gov/pagopa/mocker/service/validator/ResourceExtractor.java
@@ -133,12 +133,9 @@ public class ResourceExtractor {
     private boolean isBodyRequestSatisfyingRequirements(MockConditionEntity mockCondition, UnmarshalledBody unmarshalledBody, ExtractedRequest request) throws MockerNotCompliantRequestException {
         log.debug(String.format("Evaluating the mock condition: [%s]: [%s %s %s].", mockCondition.getId(), mockCondition.getFieldName(), mockCondition.getConditionType(), mockCondition.getConditionValue()));
         boolean isValid = false;
-        if (unmarshalledBody == null) {
-            throw new MockerNotCompliantRequestException(request.getUrl());
-        } else {
+        if (unmarshalledBody != null) {
             switch (mockCondition.getAnalyzedContentType()) {
-                case JSON:
-                case XML:
+                case JSON, XML:
                     isValid = isFieldCompliantToCondition(mockCondition, unmarshalledBody);
                     break;
                 case STRING:


### PR DESCRIPTION
This PR contains a fix made in order to resolve a bug on mock condition evaluation found during an integration test. Previously, if a request does not contains a body and a mock condition that checks body field is defined, the same check ended prematurely because the Mocker throws a `MockerNotCompliantRequestException` exception.  
Following the best practice of default rules definition (the rule to be always executed if the request is not compliant to any previous rule), this intermediate exception is not required anymore because the check at worst returns a custom body. If no default rule is defined, the Mocker throws the `MockerNotCompliantRequestException` exception anyway at the end of all conditions check, so the unnecessary intermediate throw is removed.  
Another change made is related to the default content-type in request. During the request extraction made by proxy, if no "Content-Type" header is set, it will be assigned a default value (`text/plain`) in order to avoid unparseable body and consider them as plain text.

#### List of Changes
 - Removed `MockerNotCompliantRequestException` throw if request body is not passed and there is a mock condition that make evaluation on its fields
 - Force set default content-type header in request, if this header is not passed

#### Motivation and Context
This fix permits to avoid giving always a compliance error if a request body is not passed and there is a mock condition that checks the body content.

#### How Has This Been Tested?
 - Tested in local environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.