### PR TITLE
feat: script execution after rule extraction

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopa-mocker
 description: Microservice that permits to dynamically generate mocked responses
 type: application
-version: 1.40.0
-appVersion: 1.2.7
+version: 1.41.0
+appVersion: 1.2.7-1-feat-scripting-on-mock-rule
 dependencies:
   - name: microservice-chart
     version: 3.0.0

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-mocker
-    tag: "1.2.7"
+    tag: "1.2.7-1-feat-scripting-on-mock-rule"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-mocker
-    tag: "1.2.7"
+    tag: "1.2.7-1-feat-scripting-on-mock-rule"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>it.gov.pagopa</groupId>
 	<artifactId>mocker</artifactId>
-	<version>1.2.7</version>
+	<version>1.2.7-1-feat-scripting-on-mock-rule</version>
 	<name>pagopa-mocker</name>
 	<description>An HTTP request analyzer for dynamically mocking responses</description>
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,11 @@
 			<version>2.10.1</version>
 		</dependency>
 		<dependency>
+			<groupId>org.openjdk.nashorn</groupId>
+			<artifactId>nashorn-core</artifactId>
+			<version>15.4</version>
+		</dependency>
+		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>

--- a/src/main/java/it/gov/pagopa/mocker/entity/MockResourceEntity.java
+++ b/src/main/java/it/gov/pagopa/mocker/entity/MockResourceEntity.java
@@ -26,7 +26,7 @@ public class MockResourceEntity implements Serializable {
 
     private HttpMethod httpMethod;
 
-    private List<SpecialRequestHeaderEntity> specialHeaders;
+    private List<NameValueEntity> specialHeaders;
 
     private Boolean isActive;
 

--- a/src/main/java/it/gov/pagopa/mocker/entity/MockRuleEntity.java
+++ b/src/main/java/it/gov/pagopa/mocker/entity/MockRuleEntity.java
@@ -28,4 +28,6 @@ public class MockRuleEntity implements Serializable {
     private List<MockConditionEntity> conditions;
 
     private MockResponseEntity response;
+
+    private ScriptingEntity scripting;
 }

--- a/src/main/java/it/gov/pagopa/mocker/entity/NameValueEntity.java
+++ b/src/main/java/it/gov/pagopa/mocker/entity/NameValueEntity.java
@@ -11,7 +11,7 @@ import java.io.Serializable;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder(toBuilder = true)
-public class SpecialRequestHeaderEntity implements Serializable {
+public class NameValueEntity implements Serializable {
 
     private String name;
 

--- a/src/main/java/it/gov/pagopa/mocker/entity/ScriptEntity.java
+++ b/src/main/java/it/gov/pagopa/mocker/entity/ScriptEntity.java
@@ -1,0 +1,27 @@
+package it.gov.pagopa.mocker.entity;
+
+
+import lombok.*;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import javax.persistence.Id;
+import java.io.Serializable;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(of = "id")
+@Document("scripts")
+@ToString
+public class ScriptEntity implements Serializable {
+
+    @Id
+    private String id;
+
+    private String name;
+
+    private Boolean selectable;
+
+    private String code;
+}

--- a/src/main/java/it/gov/pagopa/mocker/entity/ScriptingEntity.java
+++ b/src/main/java/it/gov/pagopa/mocker/entity/ScriptingEntity.java
@@ -1,0 +1,22 @@
+package it.gov.pagopa.mocker.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class ScriptingEntity implements Serializable {
+
+    private String scriptName;
+
+    private Boolean isActive;
+
+    private List<NameValueEntity> parameters;
+}

--- a/src/main/java/it/gov/pagopa/mocker/exception/MockerInitializationException.java
+++ b/src/main/java/it/gov/pagopa/mocker/exception/MockerInitializationException.java
@@ -1,0 +1,8 @@
+package it.gov.pagopa.mocker.exception;
+
+public class MockerInitializationException extends MockerException {
+
+    public MockerInitializationException(Exception e) {
+        super(e, "An error occurred while intializing Mocker system.");
+    }
+}

--- a/src/main/java/it/gov/pagopa/mocker/exception/MockerScriptExecutionException.java
+++ b/src/main/java/it/gov/pagopa/mocker/exception/MockerScriptExecutionException.java
@@ -1,0 +1,8 @@
+package it.gov.pagopa.mocker.exception;
+
+public class MockerScriptExecutionException extends MockerException {
+
+    public MockerScriptExecutionException(Exception e, String scriptName) {
+        super(e, String.format("The execution of the script with name [%s] ended with an error.", scriptName));
+    }
+}

--- a/src/main/java/it/gov/pagopa/mocker/repository/ScriptRepository.java
+++ b/src/main/java/it/gov/pagopa/mocker/repository/ScriptRepository.java
@@ -1,0 +1,10 @@
+package it.gov.pagopa.mocker.repository;
+
+import it.gov.pagopa.mocker.entity.ScriptEntity;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ScriptRepository extends MongoRepository<ScriptEntity, String> {
+
+}

--- a/src/main/java/it/gov/pagopa/mocker/service/scripting/ScriptExecutor.java
+++ b/src/main/java/it/gov/pagopa/mocker/service/scripting/ScriptExecutor.java
@@ -1,0 +1,79 @@
+package it.gov.pagopa.mocker.service.scripting;
+
+import it.gov.pagopa.mocker.entity.ScriptEntity;
+import it.gov.pagopa.mocker.exception.MockerInitializationException;
+import it.gov.pagopa.mocker.exception.MockerScriptExecutionException;
+import it.gov.pagopa.mocker.repository.ScriptRepository;
+import it.gov.pagopa.mocker.util.Constants;
+import it.gov.pagopa.mocker.util.Utility;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import javax.script.*;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@Slf4j
+public class ScriptExecutor {
+
+    private ScriptEngine engine;
+
+    private ScriptRepository scriptRepository;
+
+    public ScriptExecutor(ScriptRepository scriptRepository) throws MockerInitializationException {
+        ScriptEngineManager manager = new ScriptEngineManager();
+        System.setProperty("nashorn.args", "--language=es6");
+        this.engine = manager.getEngineByName("nashorn");
+        this.scriptRepository = scriptRepository;
+        initializeEngine();
+    }
+
+    private void initializeEngine() throws MockerInitializationException {
+
+        List<ScriptEntity> scriptEntities = this.scriptRepository.findAll().stream()
+                .filter(entity -> entity.getCode() != null)
+                .toList();
+
+        List<ScriptEntity> libFunctions = scriptEntities.stream()
+                .filter(e -> Boolean.FALSE.equals(e.getSelectable()))
+                .toList();
+        for (ScriptEntity scriptEntity : libFunctions) {
+            loadScript(scriptEntity);
+        }
+
+        List<ScriptEntity> customFunctions = scriptEntities.stream()
+                .filter(e -> !libFunctions.contains(e))
+                .toList();
+        for (ScriptEntity scriptEntity : customFunctions) {
+            loadScript(scriptEntity);
+        }
+    }
+
+    private void loadScript(ScriptEntity scriptEntity) throws MockerInitializationException {
+        try {
+            String scriptCode = Utility.decodeBase64(scriptEntity.getCode());
+            if (Boolean.TRUE.equals(scriptEntity.getSelectable())) {
+                String scriptName = scriptEntity.getName();
+                scriptCode = scriptCode.replace("function execute(", "function " + scriptName + Constants.SCRIPTEXECUTOR_FUNCTION_SUFFIX + "(");
+            }
+            engine.eval(scriptCode);
+        } catch (ScriptException e) {
+            log.error("An error occurred while initializing ScriptExecutor. ", e);
+            throw new MockerInitializationException(e);
+        }
+    }
+
+    @SuppressWarnings({"unchecked"})
+    public Map<String, String> execute(String scriptName, Map<String, Object> parameters) throws MockerScriptExecutionException {
+        Map<String, String> result;
+        try {
+            Bindings bindings = new SimpleBindings();
+            bindings.putAll(parameters);
+            result = (Map<String, String>) ((Invocable) engine).invokeFunction(scriptName + Constants.SCRIPTEXECUTOR_FUNCTION_SUFFIX, bindings);
+        } catch (ScriptException | NoSuchMethodException e) {
+            throw new MockerScriptExecutionException(e, scriptName);
+        }
+        return result == null ? Map.of() : result;
+    }
+}

--- a/src/main/java/it/gov/pagopa/mocker/service/validator/ResourceExtractor.java
+++ b/src/main/java/it/gov/pagopa/mocker/service/validator/ResourceExtractor.java
@@ -231,7 +231,8 @@ public class ResourceExtractor {
                     String parameterValue = parameter.getValue();
                     if (parameter.getValue().startsWith("${")) {
                         String injectedField = parameter.getValue().replace("${", "").replace("}", "");
-                        parameterValue = unmarshalledBody.getFieldValue(injectedField).toString();
+                        Object fieldValue = unmarshalledBody.getFieldValue(injectedField);
+                        parameterValue = fieldValue != null ? fieldValue.toString() : "undefined";
                     }
                     parameters.put(parameter.getName(), parameterValue);
                 }

--- a/src/main/java/it/gov/pagopa/mocker/util/Constants.java
+++ b/src/main/java/it/gov/pagopa/mocker/util/Constants.java
@@ -32,6 +32,8 @@ public class Constants {
 
     public static final String EMPTY_STRING = "";
 
+    public static final String SCRIPTEXECUTOR_FUNCTION_SUFFIX = "__execute";
+
     public static final Set<String> NOT_CACHEABLE_HEADERS_COMMON = Set.of(
             "authorization", "age", "cache-control", "etag",
             "expires", "if-modified-since", "if-none-match",


### PR DESCRIPTION
This PR contains a major feature made on Mocker system that provide the possibility to add dynamic logic during mocking process. This feature allows the execution of custom scripts when a specific mock rule occurs. For doing so, it is only needed to set the reference of the required script (and the input parameters which may be static or variable) to the mock rule on which the business logic is to be bound.

#### List of Changes
 - Added new special subsystem that permits to load all scripts at startup and execute them when mock rule with script occurs 
 - Added dedicated entity that maps the collection used for store script code to be executed by engine
 - Added information on `MockRuleEntity` that permits to refers to script code to be executed in runtime
 - Added dependency for OpenJDK's Nashorn script engine
 - Generalized `SpecialRequestHeaderEntity` entity in order to be used as a key-value pair for all needs
 - Updated parameter injection in response body in order to also permits the injection of script-returned response fields.

#### Motivation and Context
This modification broadens the use cases in which Mocker can be used, adding dynamic logic that can simplify and add expressiveness to tests.

#### How Has This Been Tested?
 - Tested in local environment
 - Tested in DEV environment

#### Screenshots (if appropriate):

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.